### PR TITLE
Update libcassandra.sh and Readme.md

### DIFF
--- a/3/debian-10/rootfs/libcassandra.sh
+++ b/3/debian-10/rootfs/libcassandra.sh
@@ -63,6 +63,7 @@ export CASSANDRA_CLUSTER_NAME="${CASSANDRA_CLUSTER_NAME:-My Cluster}"
 export CASSANDRA_DATACENTER="${CASSANDRA_DATACENTER:-dc1}"
 export CASSANDRA_ENABLE_REMOTE_CONNECTIONS="${CASSANDRA_ENABLE_REMOTE_CONNECTIONS:-true}"
 export CASSANDRA_ENABLE_RPC="${CASSANDRA_ENABLE_RPC:-true}"
+export CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS="${CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS:-false}"
 export CASSANDRA_ENDPOINT_SNITCH="${CASSANDRA_ENDPOINT_SNITCH:-SimpleSnitch}"
 export CASSANDRA_HOST="${CASSANDRA_HOST:-$(hostname)}"
 export CASSANDRA_INTERNODE_ENCRYPTION="${CASSANDRA_INTERNODE_ENCRYPTION:-none}"
@@ -277,6 +278,7 @@ cassandra_validate() {
     check_yes_no_value CASSANDRA_PASSWORD_SEEDER
     check_true_false_value CASSANDRA_ENABLE_REMOTE_CONNECTIONS
     check_true_false_value CASSANDRA_CLIENT_ENCRYPTION
+    check_true_false_value CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS
     check_positive_value CASSANDRA_NUM_TOKENS
     check_positive_value CASSANDRA_INIT_MAX_RETRIES
     check_positive_value CASSANDRA_CQL_MAX_RETRIES
@@ -452,6 +454,7 @@ cassandra_setup_cluster() {
         cassandra_yaml_set "listen_address" "$host"
         cassandra_yaml_set "seeds" "$CASSANDRA_SEEDS"
         cassandra_yaml_set "start_rpc" "$CASSANDRA_ENABLE_RPC" "no"
+        cassandra_yaml_set "enable_user_defined_functions" "$CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS" "no"
         cassandra_yaml_set "rpc_address" "$rpc_address"
         cassandra_yaml_set "broadcast_rpc_address" "$host"
         cassandra_yaml_set "endpoint_snitch" "$CASSANDRA_ENDPOINT_SNITCH"

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ cassandra:
  - `CASSANDRA_ENABLE_RPC`: Enable the thrift RPC endpoint. Default :**true**
  - `CASSANDRA_DATACENTER`: Datacenter name for the cluster. Ignored in **SimpleSnitch** endpoint snitch. Default: **dc1**.
  - `CASSANDRA_RACK`: Rack name for the cluster. Ignored in **SimpleSnitch** endpoint snitch. Default: **rack1**.
-
+ - 'CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS':  User defined functions. Default : **false**
 ## Configuration file
 
 The image looks for configurations in `/opt/bitnami/cassandra/conf/`. You can mount a volume at `/bitnami/cassandra/conf/` and copy/edit the configurations in the `/path/to/cassandra-persistence/conf/`. The default configurations will be populated to the `conf/` directory if it's empty.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ cassandra:
  - `CASSANDRA_ENABLE_RPC`: Enable the thrift RPC endpoint. Default :**true**
  - `CASSANDRA_DATACENTER`: Datacenter name for the cluster. Ignored in **SimpleSnitch** endpoint snitch. Default: **dc1**.
  - `CASSANDRA_RACK`: Rack name for the cluster. Ignored in **SimpleSnitch** endpoint snitch. Default: **rack1**.
- - 'CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS':  User defined functions. Default : **false**
+ - 'CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS':  User defined functions. Default : **false**.
+ 
 ## Configuration file
 
 The image looks for configurations in `/opt/bitnami/cassandra/conf/`. You can mount a volume at `/bitnami/cassandra/conf/` and copy/edit the configurations in the `/path/to/cassandra-persistence/conf/`. The default configurations will be populated to the `conf/` directory if it's empty.


### PR DESCRIPTION
add env CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS  in to  libcassandra.sh

Added the ability to enable the option enable_user_defined_functions via environment variables
CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS = true

#################
##docker run --name cassandra-test -p 7000: 7000 -e CASSANDRA_TRANSPORT_PORT_NUMBER = 7000 -e CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS = true cassandra-test01: latest

##docker exec -it 3a9c49a75009 bash
I have no name! @ 3a9c49a75009: / $ cat /opt/bitnami/cassandra/conf/cassandra.yaml | grep enable_user_defined_functions
enable_user_defined_functions: true
##################
we need to create functions, but we do not want to use alternative cassandra.yaml
 
something like this:
CREATE OR REPLACE FUNCTION cycling.fLog (input double) CALLED ON NULL INPUT RETURNS double LANGUAGE java AS $$ return Double.valueOf (Math.log (input.doubleValue ())); $$;
