### PR TITLE
expose broadcast address

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -71,6 +71,7 @@ export CASSANDRA_PASSWORD_SEEDER="${CASSANDRA_PASSWORD_SEEDER:-no}"
 export CASSANDRA_SEEDS="${CASSANDRA_SEEDS:-$CASSANDRA_HOST}"
 export CASSANDRA_PEERS="${CASSANDRA_PEERS:-$CASSANDRA_SEEDS}"
 export CASSANDRA_RACK="${CASSANDRA_RACK:-rack1}"
+export CASSANDRA_BROADCAST_ADDRESS="${CASSANDRA_BROADCAST_ADDRESS:-}"
 
 # Startup CQL and init-db settings
 export CASSANDRA_STARTUP_CQL="${CASSANDRA_STARTUP_CQL:-}"
@@ -462,6 +463,10 @@ cassandra_setup_cluster() {
         cassandra_yaml_set "keystore_password" "$CASSANDRA_KEYSTORE_PASSWORD"
         cassandra_yaml_set "truststore" "$CASSANDRA_TRUSTSTORE_LOCATION"
         cassandra_yaml_set "truststore_password" "$CASSANDRA_TRUSTSTORE_PASSWORD"
+
+        if [[ -n "$CASSANDRA_BROADCAST_ADDRESS" ]]; then
+            cassandra_yaml_set "broadcast_address" "$CASSANDRA_BROADCAST_ADDRESS"
+        fi
 
         cassandra_config="$(sed -E "/client_encryption_options:.*/ {N; s/client_encryption_options:[^\n]*\n\s{4}enabled:.*/client_encryption_options:\n    enabled: $CASSANDRA_CLIENT_ENCRYPTION/g}" "$CASSANDRA_CONF_FILE")"
         echo "$cassandra_config" > "$CASSANDRA_CONF_FILE"

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ cassandra:
  - `CASSANDRA_ENABLE_RPC`: Enable the thrift RPC endpoint. Default :**true**
  - `CASSANDRA_DATACENTER`: Datacenter name for the cluster. Ignored in **SimpleSnitch** endpoint snitch. Default: **dc1**.
  - `CASSANDRA_RACK`: Rack name for the cluster. Ignored in **SimpleSnitch** endpoint snitch. Default: **rack1**.
- - `CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS`:  User defined functions. Default : **false**.
- - `CASSANDRA_BROADCAST_ADDRESS`: The public IP address this node uses to broadcast to other nodes outside the network or across regions in multiple-region EC2 deployments. This option is commented out by default (if not provided, Cassandra will use "listen_address").
+ - `CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS`: User defined functions. Default: **false**.
+ - `CASSANDRA_BROADCAST_ADDRESS`: The public IP address this node uses to broadcast to other nodes outside the network or across regions in multiple-region EC2 deployments. This option is commented out by default (if not provided, Cassandra will use "listen_address"). No defaults.
 
 ## Configuration file
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ cassandra:
  - `CASSANDRA_ENABLE_RPC`: Enable the thrift RPC endpoint. Default :**true**
  - `CASSANDRA_DATACENTER`: Datacenter name for the cluster. Ignored in **SimpleSnitch** endpoint snitch. Default: **dc1**.
  - `CASSANDRA_RACK`: Rack name for the cluster. Ignored in **SimpleSnitch** endpoint snitch. Default: **rack1**.
- - 'CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS':  User defined functions. Default : **false**.
+ - `CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS`:  User defined functions. Default : **false**.
+ - `CASSANDRA_BROADCAST_ADDRESS`: The public IP address this node uses to broadcast to other nodes outside the network or across regions in multiple-region EC2 deployments. This option is commented out by default (if not provided, Cassandra will use "listen_address").
 
 ## Configuration file
 


### PR DESCRIPTION
**Description of the change**
A new environment variable CASSANDRA_BROADCAST_ADDRESS is added to support multi-region data centers in Cassandra cluster.

**Benefits**
Configuration setting "broadcast_address" will advertise current Cassandra node to other nodes located in different regions/data centers.