### PR TITLE
Expose authenticator, authorizer and add support for no authentication

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -91,7 +91,7 @@ export CASSANDRA_PEER_CQL_MAX_RETRIES="${CASSANDRA_PEER_CQL_MAX_RETRIES:-100}"
 export CASSANDRA_PEER_CQL_SLEEP_TIME="${CASSANDRA_PEER_CQL_SLEEP_TIME:-10}"
 
 # Authentication & Authorization
-export CASSANDRA_ALLOW_EMPTY_PASSWORD="${CASSANDRA_ALLOW_EMPTY_PASSWORD:-false}"
+export ALLOW_EMPTY_PASSWORD="${ALLOW_EMPTY_PASSWORD:-no}"
 export CASSANDRA_AUTHORIZER="${CASSANDRA_AUTHORIZER:-CassandraAuthorizer}"
 export CASSANDRA_AUTHENTICATOR="${CASSANDRA_AUTHENTICATOR:-PasswordAuthenticator}"
 
@@ -116,7 +116,7 @@ export CASSANDRA_PASSWORD="$(< "${CASSANDRA_PASSWORD_FILE}")"
 EOF
     else
         cat <<"EOF"
-export CASSANDRA_PASSWORD="${CASSANDRA_PASSWORD:-cassandra}"
+export CASSANDRA_PASSWORD="${CASSANDRA_PASSWORD:-}"
 EOF
     fi
     if [[ -n "${CASSANDRA_KEYSTORE_PASSWORD_FILE:-}" ]] && [[ -f "$CASSANDRA_KEYSTORE_PASSWORD_FILE" ]]; then
@@ -212,6 +212,14 @@ cassandra_validate() {
         error_code=1
     }
 
+    empty_password_enabled_warn() {
+        warn "You set the environment variable ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD}. For safety reasons, do not use this flag in a production environment."
+    }
+
+    empty_password_error() {
+        print_validation_error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
+    }
+
     check_default_password() {
         if [[ "${!1}" = "cassandra" ]]; then
             warn "You set the environment variable $1=cassandra. This is the default value when bootstrapping Cassandra and should not be used in production environments."
@@ -277,12 +285,19 @@ cassandra_validate() {
     check_password_file CASSANDRA_TRUSTSTORE_PASSWORD_FILE
     check_password_file CASSANDRA_KEYSTORE_PASSWORD_FILE
 
-    check_empty_value CASSANDRA_PASSWORD
     check_empty_value CASSANDRA_RACK
     check_empty_value CASSANDRA_DATACENTER
 
-    check_default_password CASSANDRA_PASSWORD
+    if [[ -z $CASSANDRA_PASSWORD ]]; then
+        if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+            export CASSANDRA_PASSWORD="cassandra"
+        else
+            empty_password_enabled_warn
+        fi
+    fi
 
+    check_default_password CASSANDRA_PASSWORD
+    
     if is_boolean_yes "$CASSANDRA_CLIENT_ENCRYPTION" || is_boolean_yes "$CASSANDRA_INTERNODE_ENCRYPTION"; then
         check_empty_value CASSANDRA_KEYSTORE_PASSWORD
         check_empty_value CASSANDRA_TRUSTSTORE_PASSWORD
@@ -421,7 +436,7 @@ cassandra_setup_data_dirs() {
 #########################
 cassandra_enable_auth() {
     if ! cassandra_is_file_external "cassandra.yaml"; then
-        if [[ "$CASSANDRA_ALLOW_EMPTY_PASSWORD" = "true" ]]; then
+        if [[ "$ALLOW_EMPTY_PASSWORD" = "yes" ]] && [[ -z $CASSANDRA_PASSWORD ]]; then
             cassandra_yaml_set "authenticator" "AllowAllAuthenticator"
             cassandra_yaml_set "authorizer" "AllowAllAuthorizer"
         else

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -216,6 +216,10 @@ cassandra_validate() {
         warn "You set the environment variable ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD}. For safety reasons, do not use this flag in a production environment."
     }
 
+    empty_password_warn() {
+        warn "You've not provided a password. Default password \"cassandra\" will be used. For safety reasons, please provide a secure password in a production environment."
+    }
+
     empty_password_error() {
         print_validation_error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
     }
@@ -290,6 +294,7 @@ cassandra_validate() {
 
     if [[ -z $CASSANDRA_PASSWORD ]]; then
         if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+            empty_password_warn
             export CASSANDRA_PASSWORD="cassandra"
         else
             empty_password_enabled_warn

--- a/README.md
+++ b/README.md
@@ -270,6 +270,25 @@ cassandra:
     - CASSANDRA_PASSWORD=password123
 ```
 
+## Allowing empty passwords
+
+By default the Cassandra image expects all the available passwords to be set. In order to allow empty passwords, it is necessary to set the `ALLOW_EMPTY_PASSWORD=yes` env variable. This env variable is only recommended for testing or development purposes. We strongly recommend specifying the `CASSANDRA_PASSWORD` for any other scenario.
+
+```console
+$ docker run --name cassandra -e ALLOW_EMPTY_PASSWORD=yes bitnami/cassandra:latest
+```
+
+Alternatively, modify the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-cassandra/blob/master/docker-compose.yml) file present in this repository:
+
+```yaml
+services:
+  cassandra:
+  ...
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+  ...
+```
+
 ## Setting up a cluster
 
 A cluster can easily be setup with the Bitnami Cassandra Docker Image. **In case you do not mount custom configuration files**, you can use the following environment variables:

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ cassandra:
  - `CASSANDRA_TRANSPORT_PORT_NUMBER`: Inter-node cluster communication port. Default: **7000**
  - `CASSANDRA_JMX_PORT_NUMBER`: JMX connections port. Default: **7199**
  - `CASSANDRA_CQL_PORT_NUMBER`: Client port. Default: **9042**.
+ - `CASSANDRA_ALLOW_EMPTY_PASSWORD`: Allow login without password (not recommended for production use). Default: **false**
+ - `CASSANDRA_AUTHORIZER`: Cassandra authorizer. Default: **PasswordAuthorizer**
+ - `CASSANDRA_AUTHENTICATOR`: Cassandra authenticator. Default: **PasswordAuthenticator**
  - `CASSANDRA_USER`: Cassandra user name. Defaults: **cassandra**
  - `CASSANDRA_PASSWORD_SEEDER`: Password seeder will change the Cassandra default credentials at initialization. In clusters, only one node should be marked as password seeder. Default: **no**
  - `CASSANDRA_PASSWORD`: Cassandra user password. Default: **cassandra**


### PR DESCRIPTION
Description of the change
A new environment variable CASSANDRA_AUTHENTICATOR, CASSANDRA_AUTHORIZER is added to support defining authenticator and authorizer in Cassandra cluster.
Also, a new environment variable CASSANDRA_ALLOW_EMPTY_PASSWORD is added to support non password login. For development purposes only.

Benefits
Configuration setting "authenticator", "authorizer" are used to define which authenticator and/or authorizer to be used.
Also, environment variable CASSANDRA_ALLOW_EMPTY_PASSWORD will allow Cassandra to run with no authentication (for development purposes only) by setting "authenticator" and "authorizer" to "AllowAllAuthenticator" and "AllowAllAuthorizer".