### PR TITLE
Update libcassandra.sh

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -826,6 +826,7 @@ cassandra_execute() {
     local -r keyspace="${3:-}"
     local -r host="${4:-localhost}"
     local -r extra_args="${5:-}"
+    local -r port="${CASSANDRA_CQL_PORT_NUMBER}"
     local -r cmd=("${CASSANDRA_BIN_DIR}/cqlsh")
     local args=("-u" "$user" "-p" "$pass")
 
@@ -833,6 +834,7 @@ cassandra_execute() {
     [[ -n "$keyspace" ]] && args+=("-k" "$keyspace")
     [[ -n "$extra_args" ]] && args+=($extra_args)
     args+=("$host")
+    args+=("$port")
     if [[ "${BITNAMI_DEBUG}" = true ]]; then
         local -r command="$(cat)"
         debug "Executing CQL \"$command\""


### PR DESCRIPTION
CQL Port at initial startup. 
Start Container the first time with CASSANDRA_CQL_PORT_NUMBER defined other then default - cassandra_execute will fail with connection issue. It tries to connect to default port 9042

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
