### PR TITLE
Revert pre-creation of CASSANDRA_COMMITLOG_DIR

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -709,7 +709,7 @@ cassandra_initialize() {
     is_boolean_yes "$CASSANDRA_CLIENT_ENCRYPTION" && cassandra_setup_client_ssl
 
     debug "Ensuring expected directories/files exist..."
-    for dir in "$CASSANDRA_DATA_DIR" "$CASSANDRA_TMP_DIR" "$CASSANDRA_LOG_DIR" "$CASSANDRA_COMMITLOG_DIR"; do
+    for dir in "$CASSANDRA_DATA_DIR" "$CASSANDRA_TMP_DIR" "$CASSANDRA_LOG_DIR"; do
         ensure_dir_exists "$dir"
         am_i_root && chown -R "$CASSANDRA_DAEMON_USER:$CASSANDRA_DAEMON_GROUP" "$dir"
     done


### PR DESCRIPTION
Follow-up of #86.

For some reason the directory can't be pre-created and empty when Cassandra starts. It should be due to some internal check.