### PR TITLE
Add env vars to configure Cassandra properties files

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -1174,6 +1174,7 @@ cassandra_commitlog_conf_set() {
 cassandra_setup_from_environment_variables() {
     # Map environment variables to config properties for cassandra-env.sh
     for var in "${!CASSANDRA_CFG_ENV_@}"; do
+        # shellcheck disable=SC2001
         key="$(echo "$var" | sed -e 's/^CASSANDRA_CFG_ENV_//g')"
         value="${!var}"
         cassandra_env_conf_set "$key" "$value"

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -706,6 +706,8 @@ cassandra_initialize() {
     cassandra_setup_rack_dc
     cassandra_setup_data_dirs
     cassandra_setup_cluster
+    cassandra_setup_from_environment_variables # Give priority to users configuration
+
     is_boolean_yes "$CASSANDRA_CLIENT_ENCRYPTION" && cassandra_setup_client_ssl
 
     debug "Ensuring expected directories/files exist..."
@@ -1078,4 +1080,114 @@ is_cassandra_running() {
     else
         is_service_running "$pid"
     fi
+}
+
+########################
+# Set a configuration setting value to a file
+# Globals:
+#   None
+# Arguments:
+#   $1 - file
+#   $2 - key
+#   $3 - values (array)
+# Returns:
+#   None
+#########################
+cassandra_common_conf_set() {
+    local file="${1:?missing file}"
+    local key="${2:?missing key}"
+    shift
+    shift
+    local values=("$@")
+
+    if [[ "${#values[@]}" -eq 0 ]]; then
+        stderr_print "missing value"
+        return 1
+    elif [[ "${#values[@]}" -ne 1 ]]; then
+        for i in "${!values[@]}"; do
+            cassandra_common_conf_set "$file" "${key[$i]}" "${values[$i]}"
+        done
+    else
+        value="${values[0]}"
+        # Check if the value was set before
+        if grep -q "^[#\\s]*$key\s*=.*" "$file"; then
+            # Update the existing key
+            replace_in_file "$file" "^[#\\s]*${key}\s*=.*" "${key}=${value}" false
+        else
+            # Add a new key
+            printf '\n%s=%s' "$key" "$value" >>"$file"
+        fi
+    fi
+}
+
+########################
+# Set a configuration setting value to cassandra-env.sh
+# Globals:
+#   CASSANDRA_CONF_DIR
+# Arguments:
+#   $1 - key
+#   $2 - values (array)
+# Returns:
+#   None
+#########################
+cassandra_env_conf_set() {
+    cassandra_common_conf_set "${CASSANDRA_CONF_DIR}/cassandra-env.sh" "$@"
+}
+
+########################
+# Set a configuration setting value to cassandra-rackdc.properties
+# Globals:
+#   CASSANDRA_CONF_DIR
+# Arguments:
+#   $1 - key
+#   $2 - values (array)
+# Returns:
+#   None
+#########################
+cassandra_rackdc_conf_set() {
+    cassandra_common_conf_set "${CASSANDRA_CONF_DIR}/cassandra-rackdc.properties" "$@"
+}
+
+########################
+# Set a configuration setting value to commitlog_archiving.properties
+# Globals:
+#   CASSANDRA_CONF_DIR
+# Arguments:
+#   $1 - key
+#   $2 - values (array)
+# Returns:
+#   None
+#########################
+cassandra_commitlog_conf_set() {
+    cassandra_common_conf_set "${CASSANDRA_CONF_DIR}/commitlog_archiving.properties" "$@"
+}
+
+########################
+# Configure Cassandra configuration files from environment variables
+# Globals:
+#   CASSANDRA_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+cassandra_setup_from_environment_variables() {
+    # Map environment variables to config properties for cassandra-env.sh
+    for var in "${!CASSANDRA_CFG_ENV_@}"; do
+        key="$(echo "$var" | sed -e 's/^CASSANDRA_CFG_ENV_//g')"
+        value="${!var}"
+        cassandra_env_conf_set "$key" "$value"
+    done
+    # Map environment variables to config properties for cassandra-rackdc.properties
+    for var in "${!CASSANDRA_CFG_RACKDC_@}"; do
+        key="$(echo "$var" | sed -e 's/^CASSANDRA_CFG_RACKDC_//g' | tr '[:upper:]' '[:lower:]')"
+        value="${!var}"
+        cassandra_rackdc_conf_set "$key" "$value"
+    done
+    # Map environment variables to config properties for commitlog_archiving.properties
+    for var in "${!CASSANDRA_CFG_COMMITLOG_@}"; do
+        key="$(echo "$var" | sed -e 's/^CASSANDRA_CFG_COMMITLOG_//g' | tr '[:upper:]' '[:lower:]')"
+        value="${!var}"
+        cassandra_commitlog_conf_set "$key" "$value"
+    done
 }

--- a/README.md
+++ b/README.md
@@ -209,6 +209,22 @@ Additionally, any environment variable beginning with the following prefix will 
 - `CASSANDRA_CFG_RACKDC_`: Will add the corresponding key and the provided value to `cassandra-rackdc.properties`.
 - `CASSANDRA_CFG_COMMITLOG_`: Will add the corresponding key and the provided value to `commitlog_archiving.properties`.
 
+For example, use `CASSANDRA_CFG_RACKDC_PREFER_LOCAL` in order to configure `prefer_local` in `cassandra-rackdc.properties`:
+
+```console
+$ docker run --name cassandra -e CASSANDRA_CFG_RACKDC_PREFER_LOCAL=true bitnami/cassandra:latest
+```
+
+or modifying the `docker-compose.yaml` with:
+
+```
+cassandra:
+  ...
+  environment:
+    - CASSANDRA_CFG_RACKDC_PREFER_LOCAL=true
+  ...
+```
+
 ## Configuration file
 
 The image looks for configurations in `/opt/bitnami/cassandra/conf/`. You can mount a volume at `/bitnami/cassandra/conf/` and copy/edit the configurations in the `/path/to/cassandra-persistence/conf/`. The default configurations will be populated to the `conf/` directory if it's empty.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ cassandra:
  - `CASSANDRA_BROADCAST_ADDRESS`: The public IP address this node uses to broadcast to other nodes outside the network or across regions in multiple-region EC2 deployments. This option is commented out by default (if not provided, Cassandra will use "listen_address"). No defaults.
  - `CASSANDRA_COMMITLOG_DIR`: Directory where the commit logs will be stored. Default: **/bitnami/cassandra/data/commitlog**
 
+Additionally, any environment variable beginning with the following prefix will be mapped to its corresponding Cassandra key in the proper file:
+
+- `CASSANDRA_CFG_ENV_`: Will add the corresponding key and the provided value to `cassandra-env.sh`.
+- `CASSANDRA_CFG_RACKDC_`: Will add the corresponding key and the provided value to `cassandra-rackdc.properties`.
+- `CASSANDRA_CFG_COMMITLOG_`: Will add the corresponding key and the provided value to `commitlog_archiving.properties`.
+
 ## Configuration file
 
 The image looks for configurations in `/opt/bitnami/cassandra/conf/`. You can mount a volume at `/bitnami/cassandra/conf/` and copy/edit the configurations in the `/path/to/cassandra-persistence/conf/`. The default configurations will be populated to the `conf/` directory if it's empty.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR allows to setup every property of the properties files from Cassandra except the topology one that requires the IPs and they will be dynamic in Kubernetes, so they should not be manually set.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**
fixes #67
fixes https://github.com/bitnami/charts/issues/2190
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
